### PR TITLE
Do not throw error on non-number limit, just default to no limit (esp…

### DIFF
--- a/fgitvis.Console/Program.fs
+++ b/fgitvis.Console/Program.fs
@@ -24,8 +24,11 @@ let main argv =
     printfn "You've chosen well, we'll calculate the '%s' report now." reportChosen.Description
 
     let fileLimit = UserInput.requestFileLimit    
-    
-    let applyLimit = (fun xs -> if fileLimit = 0 then xs else Seq.truncate fileLimit xs)
+    let applyLimit = 
+      match fileLimit with
+      | Some limit -> Seq.truncate limit
+      | None -> id
+
     let showChart (chart: ChartTypes.GenericChart) = Application.Run(chart.ShowChart())
     
     // Step through our menu declarations and pull apart the operations to run

--- a/fgitvis.Console/UserInput.fs
+++ b/fgitvis.Console/UserInput.fs
@@ -29,6 +29,6 @@ let requestMenuItem () =
 let requestFileLimit =
     let userInput = UserInputHelper.getUserInput "Please enter a numeric limit to the number of files we should graph: "
     let success, limit = Int32.TryParse(userInput)
-    if (not success) || limit < 0 then
-        failwith "Limit must be a positive integer (or 0 if you want to show all files)."
-    limit;
+    if success && limit > 0 
+    then Some limit
+    else None


### PR DESCRIPTION
When first run the tool, I just pressed Enter on limit and got a crash ("not a valid number").
Since you asked for PRs to make it more functional :) I change the return type of `requestFileLimit` to Option and then I simply ignore anything non-valid.